### PR TITLE
Added basic object ID randomization

### DIFF
--- a/so2/entities/GameLiveData.py
+++ b/so2/entities/GameLiveData.py
@@ -150,7 +150,7 @@ class GameLiveData:
     def reprJSON(self, stateLiveData: StateLiveData):
         return {
             "objects": {
-                "hives": {str(hive.id): hive.reprJSON(stateLiveData.config, self.hiveZones) for hive in
+                "hives": {str(stateLiveData.idRandomization[hive.id]): hive.reprJSON(stateLiveData.config, self.hiveZones, idOverride=stateLiveData.idRandomization[hive.id]) for hive in
                           stateLiveData.hives},
                 "robots": {str(robot.id): robot.reprJSON() for robot in stateLiveData.robots}
             },

--- a/so2/entities/Hive.py
+++ b/so2/entities/Hive.py
@@ -33,11 +33,12 @@ class Hive(MovableObject):
             else:
                 return config.points[Config.HOME.value]
 
-    def reprJSON(self, config: ConfigMap, hiveZones: Dict[int, List[FieldsNames]]):
+    def reprJSON(self, config: ConfigMap, hiveZones: Dict[int, List[FieldsNames]], idOverride: int):
         json = super().reprJSON()
         json["type"] = self.hiveType.value
         json["points"] = {
             "team1": self.getPoints(Config.TEAM1, config, hiveZones),
             "team2": self.getPoints(Config.TEAM2, config, hiveZones)
         }
+        json["id"] = idOverride
         return json

--- a/so2/entities/StateLiveData.py
+++ b/so2/entities/StateLiveData.py
@@ -1,5 +1,6 @@
 import logging
 from typing import Dict, List
+from random import randint
 
 from sledilnik.classes.Field import Field
 from sledilnik.classes.MovableObject import MovableObject
@@ -18,6 +19,7 @@ class StateLiveData:
         self.fields: Dict[str, Field] = {}
         self.zones: Dict[str, Field] = {}
         self.config: ConfigMap = ConfigMap()
+        self.idRandomization: Dict[int, int] = {}
 
     def parseTrackerLiveData(self, data: TrackerLiveData):
         self.fields = data.fields
@@ -29,7 +31,21 @@ class StateLiveData:
         for key, obj in objects.items():
             if key in self.config.healthyHives:
                 self.hives.append(Hive(obj, HiveType.HIVE_HEALTHY))
+                self.assignRandomID(obj)
             elif key in self.config.diseasedHives:
                 self.hives.append(Hive(obj, HiveType.HIVE_DISEASED))
+                self.assignRandomID(obj)
             else:
                 self.robots.append(obj)
+
+    def assignRandomID(self, obj: MovableObject):
+        # check if the object already has a random id
+        if obj.id in self.idRandomization.keys():
+            return
+        
+        newID = randint(1000, 9999)
+        # ensure the IDs are not duplicated
+        while newID in self.idRandomization.values():
+            newID = randint(1000, 9999)
+
+        self.idRandomization[obj.id] = newID


### PR DESCRIPTION
Solution not yet tested in live environment. The updates make the game engine assign a random 4 digit ID to every Hive object when they are scanned for the first time during a game. The translation dictionary is stored in `StateLiveData.idRandomization` and could be made available via the API to the creator of the game.